### PR TITLE
update the publication check to look for the correct meta key

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -112,7 +112,7 @@ function register_seo_title() {
 			'page',
 		],
 		'run_check' => function ( array $post, array $meta ) : Status {
-			$meta_title = $meta['_meta_title'] ?? [];
+			$meta_title = $meta['_yoast_wpseo_title'] ?? [];
 			$status = ( count( $meta_title ) !== 1 || empty( $meta_title[0] ) ) ? Status::INCOMPLETE : Status::COMPLETE;
 
 			return new Status( $status, 'Add a custom SEO title' );


### PR DESCRIPTION
### issue 
"Add custom SEO title" unable to be checked off, and therefore the checklist can't be completed. [#53](https://github.com/humanmade/altis-demo/issues/53)

### solution
 When adding an "SEO title" the item, "Add custom SEO title",  is marked as completed when the field has been set to a non-empty string.
##### Steps to test
1. Create a new post.
2. Add a post title and some content.
3. Scroll to the **Yoast SEO** section below the post content.
4. In the **SEO title** field, add your custom title.
5. **Save draft** or **Publish** the page
6. Reloading the page and viewing the **Publication Checklist** will now show **Add a custom SEO title** as completed.

### screenshot
![Screenshot 2022-02-08 at 15 55 47](https://user-images.githubusercontent.com/16571365/153001740-58e7feb5-fba6-4087-98f0-5b302958df66.png)


